### PR TITLE
Replace claims/pubprivkey auth with random names + secrets, fix N+1 queries

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@xtr-dev/rondevu-server",
   "version": "0.5.4",
-  "description": "DNS-like WebRTC signaling server with username claiming and service discovery",
+  "description": "DNS-like WebRTC signaling server with credential-based authentication and service discovery",
   "main": "dist/index.js",
   "scripts": {
     "build": "node build.js",
@@ -21,7 +21,6 @@
   },
   "dependencies": {
     "@hono/node-server": "^1.19.6",
-    "@noble/ed25519": "^3.0.0",
     "@xtr-dev/rondevu-client": "^0.13.0",
     "better-sqlite3": "^12.4.1",
     "hono": "^4.10.4"

--- a/src/app.ts
+++ b/src/app.ts
@@ -22,7 +22,7 @@ export function createApp(storage: Storage, config: Config) {
       return config.corsOrigins[0];
     },
     allowMethods: ['GET', 'POST', 'OPTIONS'],
-    allowHeaders: ['Content-Type', 'Origin', 'X-Username', 'X-Timestamp', 'X-Signature', 'X-Public-Key'],
+    allowHeaders: ['Content-Type', 'Origin', 'X-Name', 'X-Secret'],
     exposeHeaders: ['Content-Type'],
     credentials: false,
     maxAge: 86400,
@@ -33,7 +33,7 @@ export function createApp(storage: Storage, config: Config) {
     return c.json({
       version: config.version,
       name: 'Rondevu',
-      description: 'WebRTC signaling with RPC interface and Ed25519 authentication',
+      description: 'WebRTC signaling with RPC interface and simple secret-based authentication',
     }, 200);
   });
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -18,8 +18,6 @@ export interface Config {
   maxCandidateSize: number;
   maxCandidateDepth: number;
   maxCandidatesPerRequest: number;
-  timestampMaxAge: number;
-  timestampMaxFuture: number;
   maxTotalOperations: number;
 }
 
@@ -45,8 +43,6 @@ export function loadConfig(): Config {
     maxCandidateSize: parseInt(process.env.MAX_CANDIDATE_SIZE || String(4 * 1024), 10), // 4KB
     maxCandidateDepth: parseInt(process.env.MAX_CANDIDATE_DEPTH || '10', 10),
     maxCandidatesPerRequest: parseInt(process.env.MAX_CANDIDATES_PER_REQUEST || '100', 10),
-    timestampMaxAge: parseInt(process.env.TIMESTAMP_MAX_AGE || '300000', 10), // 5 minutes
-    timestampMaxFuture: parseInt(process.env.TIMESTAMP_MAX_FUTURE || '60000', 10), // 1 minute
     maxTotalOperations: parseInt(process.env.MAX_TOTAL_OPERATIONS || '1000', 10) // Total ops across batch
   };
 }

--- a/src/crypto.ts
+++ b/src/crypto.ts
@@ -31,8 +31,10 @@ export function generateCredentialName(): string {
   const adjective = adjectives[Math.floor(Math.random() * adjectives.length)];
   const noun = nouns[Math.floor(Math.random() * nouns.length)];
 
-  // Generate 4-character hex suffix for uniqueness
-  const random = crypto.getRandomValues(new Uint8Array(2));
+  // Generate 8-character hex suffix for uniqueness (4 bytes = 2^32 combinations)
+  // With 576 adjective-noun pairs, total space: 576 × 2^32 ≈ 2.5 trillion names
+  // Birthday paradox collision at ~1.6 million credentials (safe for most deployments)
+  const random = crypto.getRandomValues(new Uint8Array(4));
   const hex = Array.from(random).map(b => b.toString(16).padStart(2, '0')).join('');
 
   return `${adjective}-${noun}-${hex}`;

--- a/src/crypto.ts
+++ b/src/crypto.ts
@@ -22,9 +22,47 @@ const USERNAME_MAX_LENGTH = 32;
 const TIMESTAMP_TOLERANCE_MS = 5 * 60 * 1000;
 
 /**
+ * Generates a random credential name
+ * Format: {adjective}-{noun}-{random}
+ * Example: "brave-tiger-7a3f", "quick-river-9b2e"
+ */
+export function generateCredentialName(): string {
+  const adjectives = [
+    'brave', 'calm', 'eager', 'fancy', 'gentle', 'happy', 'jolly', 'kind',
+    'lively', 'merry', 'nice', 'proud', 'quiet', 'swift', 'witty', 'young',
+    'bright', 'clever', 'daring', 'fair', 'grand', 'humble', 'noble', 'quick'
+  ];
+
+  const nouns = [
+    'tiger', 'eagle', 'river', 'mountain', 'ocean', 'forest', 'desert', 'valley',
+    'thunder', 'wind', 'fire', 'stone', 'cloud', 'star', 'moon', 'sun',
+    'wolf', 'bear', 'hawk', 'lion', 'fox', 'deer', 'owl', 'swan'
+  ];
+
+  const adjective = adjectives[Math.floor(Math.random() * adjectives.length)];
+  const noun = nouns[Math.floor(Math.random() * nouns.length)];
+
+  // Generate 4-character hex suffix for uniqueness
+  const random = crypto.getRandomValues(new Uint8Array(2));
+  const hex = Array.from(random).map(b => b.toString(16).padStart(2, '0')).join('');
+
+  return `${adjective}-${noun}-${hex}`;
+}
+
+/**
+ * Generates a random secret (API key style)
+ * Format: 32-character hex string (128 bits of entropy)
+ */
+export function generateSecret(): string {
+  const bytes = crypto.getRandomValues(new Uint8Array(16));
+  return Array.from(bytes).map(b => b.toString(16).padStart(2, '0')).join('');
+}
+
+/**
  * Generates an anonymous username for users who don't want to claim one
  * Format: anon-{timestamp}-{random}
  * This reduces collision probability to near-zero
+ * @deprecated Use generateCredentialName() instead
  */
 export function generateAnonymousUsername(): string {
   const timestamp = Date.now().toString(36);

--- a/src/rpc.ts
+++ b/src/rpc.ts
@@ -1,5 +1,5 @@
 import { Context } from 'hono';
-import { Storage, StorageError, StorageErrorCode } from './storage/types.ts';
+import { Storage } from './storage/types.ts';
 import { Config } from './config.ts';
 import {
   validateServiceFqn,
@@ -238,9 +238,9 @@ const handlers: Record<string, RpcHandler> = {
 
   /**
    * Get offer by FQN - Supports 3 modes:
-   * 1. Direct lookup: FQN includes @username
-   * 2. Paginated discovery: FQN without @username, with limit/offset
-   * 3. Random discovery: FQN without @username, no limit
+   * 1. Direct lookup: FQN includes @name (e.g., chat:1.0.0@brave-tiger-7a3f)
+   * 2. Paginated discovery: FQN without @name, with limit/offset
+   * 3. Random discovery: FQN without @name, no limit
    */
   async getOffer(params: GetOfferParams, name, secret, storage, config, request: RpcRequest) {
     const { serviceFqn, limit, offset } = params;

--- a/src/storage/d1.ts
+++ b/src/storage/d1.ts
@@ -4,12 +4,10 @@ import {
   Offer,
   IceCandidate,
   CreateOfferRequest,
-  Username,
-  ClaimUsernameRequest,
+  Credential,
+  GenerateCredentialsRequest,
   Service,
   CreateServiceRequest,
-  StorageError,
-  StorageErrorCode,
 } from './types.ts';
 import { generateOfferHash } from './hash-id.ts';
 import { parseServiceFqn } from '../crypto.ts';

--- a/src/storage/sqlite.ts
+++ b/src/storage/sqlite.ts
@@ -5,12 +5,10 @@ import {
   Offer,
   IceCandidate,
   CreateOfferRequest,
-  Username,
-  ClaimUsernameRequest,
+  Credential,
+  GenerateCredentialsRequest,
   Service,
   CreateServiceRequest,
-  StorageError,
-  StorageErrorCode,
 } from './types.ts';
 import { generateOfferHash } from './hash-id.ts';
 import { parseServiceFqn } from '../crypto.ts';

--- a/src/storage/sqlite.ts
+++ b/src/storage/sqlite.ts
@@ -85,6 +85,15 @@ export class SQLiteStorage implements Storage {
       CREATE INDEX IF NOT EXISTS idx_credentials_expires ON credentials(expires_at);
       CREATE INDEX IF NOT EXISTS idx_credentials_secret ON credentials(secret);
 
+      -- Rate limits table (for distributed rate limiting)
+      CREATE TABLE IF NOT EXISTS rate_limits (
+        identifier TEXT PRIMARY KEY,
+        count INTEGER NOT NULL,
+        reset_time INTEGER NOT NULL
+      );
+
+      CREATE INDEX IF NOT EXISTS idx_rate_limits_reset ON rate_limits(reset_time);
+
       -- Services table (new schema with extracted fields for discovery)
       CREATE TABLE IF NOT EXISTS services (
         id TEXT PRIMARY KEY,
@@ -500,6 +509,47 @@ export class SQLiteStorage implements Storage {
     return result.changes;
   }
 
+  // ===== Rate Limiting =====
+
+  async checkRateLimit(identifier: string, limit: number, windowMs: number): Promise<boolean> {
+    const now = Date.now();
+    const resetTime = now + windowMs;
+
+    // Get current rate limit entry
+    const entry = this.db.prepare(`
+      SELECT count, reset_time FROM rate_limits WHERE identifier = ?
+    `).get(identifier) as { count: number; reset_time: number } | undefined;
+
+    if (!entry || entry.reset_time < now) {
+      // First request or expired window - allow and reset
+      this.db.prepare(`
+        INSERT OR REPLACE INTO rate_limits (identifier, count, reset_time)
+        VALUES (?, 1, ?)
+      `).run(identifier, resetTime);
+      return true;
+    }
+
+    if (entry.count >= limit) {
+      // Rate limit exceeded
+      return false;
+    }
+
+    // Increment count
+    this.db.prepare(`
+      UPDATE rate_limits
+      SET count = count + 1
+      WHERE identifier = ?
+    `).run(identifier);
+
+    return true;
+  }
+
+  async deleteExpiredRateLimits(now: number): Promise<number> {
+    const stmt = this.db.prepare('DELETE FROM rate_limits WHERE reset_time < ?');
+    const result = stmt.run(now);
+    return result.changes;
+  }
+
   // ===== Service Management =====
 
   async createService(request: CreateServiceRequest): Promise<{
@@ -694,10 +744,29 @@ export class SQLiteStorage implements Storage {
     return rows.map(row => this.rowToService(row));
   }
 
-  async getRandomService(serviceName: string, version: string): Promise<Service | null> {
-    // Get a random service with an available offer
+  async getRandomService(serviceName: string, version: string): Promise<{ service: Service; offer: Offer } | null> {
+    // Get a random service with an available offer (in single query to avoid N+1)
     const stmt = this.db.prepare(`
-      SELECT s.* FROM services s
+      SELECT
+        s.id as service_id,
+        s.service_fqn,
+        s.service_name,
+        s.version,
+        s.username,
+        s.created_at as service_created_at,
+        s.expires_at as service_expires_at,
+        o.id as offer_id,
+        o.username as offer_username,
+        o.service_id as offer_service_id,
+        o.service_fqn as offer_service_fqn,
+        o.sdp,
+        o.created_at as offer_created_at,
+        o.expires_at as offer_expires_at,
+        o.last_seen,
+        o.answerer_username,
+        o.answer_sdp,
+        o.answered_at
+      FROM services s
       INNER JOIN offers o ON o.service_id = s.id
       WHERE s.service_name = ?
         AND s.version = ?
@@ -714,7 +783,31 @@ export class SQLiteStorage implements Storage {
       return null;
     }
 
-    return this.rowToService(row);
+    const service: Service = {
+      id: row.service_id,
+      serviceFqn: row.service_fqn,
+      serviceName: row.service_name,
+      version: row.version,
+      username: row.username,
+      createdAt: row.service_created_at,
+      expiresAt: row.service_expires_at,
+    };
+
+    const offer: Offer = {
+      id: row.offer_id,
+      username: row.offer_username,
+      serviceId: row.offer_service_id || undefined,
+      serviceFqn: row.offer_service_fqn || undefined,
+      sdp: row.sdp,
+      createdAt: row.offer_created_at,
+      expiresAt: row.offer_expires_at,
+      lastSeen: row.last_seen,
+      answererUsername: row.answerer_username || undefined,
+      answerSdp: row.answer_sdp || undefined,
+      answeredAt: row.answered_at || undefined,
+    };
+
+    return { service, offer };
   }
 
   async deleteService(serviceId: string, username: string): Promise<boolean> {

--- a/src/storage/types.ts
+++ b/src/storage/types.ts
@@ -230,6 +230,24 @@ export interface Storage {
    */
   deleteExpiredCredentials(now: number): Promise<number>;
 
+  // ===== Rate Limiting =====
+
+  /**
+   * Check and increment rate limit for an identifier
+   * @param identifier Unique identifier (e.g., IP address)
+   * @param limit Maximum count allowed
+   * @param windowMs Time window in milliseconds
+   * @returns true if allowed, false if rate limit exceeded
+   */
+  checkRateLimit(identifier: string, limit: number, windowMs: number): Promise<boolean>;
+
+  /**
+   * Deletes all expired rate limit entries
+   * @param now Current timestamp
+   * @returns Number of entries deleted
+   */
+  deleteExpiredRateLimits(now: number): Promise<number>;
+
   // ===== Service Management =====
 
   /**
@@ -298,7 +316,7 @@ export interface Storage {
    * @param version Version string for semver matching (e.g., '1.0.0')
    * @returns Random service with available offer, or null if none found
    */
-  getRandomService(serviceName: string, version: string): Promise<Service | null>;
+  getRandomService(serviceName: string, version: string): Promise<{ service: Service; offer: Offer } | null>;
 
   /**
    * Deletes a service (with ownership verification)

--- a/src/storage/types.ts
+++ b/src/storage/types.ts
@@ -1,29 +1,4 @@
 /**
- * Custom error types for storage layer operations
- * Provides type-safe error handling across different storage backends
- */
-export enum StorageErrorCode {
-  USERNAME_CONFLICT = 'USERNAME_CONFLICT', // Username already claimed by different key
-  PUBLIC_KEY_CONFLICT = 'PUBLIC_KEY_CONFLICT', // Public key already claimed different username
-  CONSTRAINT_VIOLATION = 'CONSTRAINT_VIOLATION', // Generic constraint violation
-}
-
-/**
- * Custom error class for storage layer
- * Allows RPC layer to handle errors without relying on string matching
- */
-export class StorageError extends Error {
-  constructor(
-    public code: StorageErrorCode,
-    message: string,
-    public cause?: Error
-  ) {
-    super(message);
-    this.name = 'StorageError';
-  }
-}
-
-/**
  * Represents a WebRTC signaling offer
  */
 export interface Offer {
@@ -86,14 +61,14 @@ export interface GenerateCredentialsRequest {
 
 /**
  * Represents a published service (can have multiple offers)
- * New format: service:version@username (e.g., chat:1.0.0@alice)
+ * Format: service:version@name (e.g., chat:1.0.0@brave-tiger-7a3f)
  */
 export interface Service {
   id: string; // UUID v4
-  serviceFqn: string; // Full FQN: chat:1.0.0@alice
+  serviceFqn: string; // Full FQN: chat:1.0.0@brave-tiger-7a3f
   serviceName: string; // Extracted: chat
   version: string; // Extracted: 1.0.0
-  username: string; // Extracted: alice
+  username: string; // Extracted: brave-tiger-7a3f (kept as "username" for compatibility)
   createdAt: number;
   expiresAt: number;
 }


### PR DESCRIPTION
Major authentication system refactor:
- Replace Ed25519 signature-based authentication with simpler secret-based auth
- Generate random credential names (e.g., "brave-tiger-7a3f") + secrets
- Add generateCredentials endpoint (no auth required)
- Remove claimUsername and getUser endpoints
- Credentials expire after 365 days if not used (same as before)
- Update CORS headers: X-Name and X-Secret instead of X-Username, X-Timestamp, X-Signature, X-Public-Key

Performance improvements:
- Add batch method getIceCandidatesForMultipleOffers() to fix N+1 query in poll endpoint
- Uses JOIN to fetch all ICE candidates in single query instead of looping

Database schema changes:
- Rename usernames table to credentials table
- Replace (username, public_key) with (name, secret)
- Update foreign key references in services table
- Add indexes on credentials.secret and credentials.expires_at

Breaking changes:
- Old authentication headers no longer work
- Clients must use generateCredentials to get name + secret
- All authenticated requests require X-Name and X-Secret headers